### PR TITLE
minor fix for Publish filter/search bar

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -7101,6 +7101,14 @@ body:not(.show-graph-controls) .graph-controls.is-close:not(:hover) {
 }
 
 /* ───────────────────────────────────────────────────
+<< Publish
+─────────────────────────────────────────────────── */
+/* ensures Publish search bar plays fine */
+.publish-changes-info input[type="email"], input[type="password"], input[type="search"], input[type="text"] {
+    width: 100%;
+}
+
+/* ───────────────────────────────────────────────────
 < Community Plugins
 ─────────────────────────────────────────────────── */
 


### PR DESCRIPTION
Currently, the Publish filter is too large as it takes `input[type="email"], input[type="password"], input[type="search"], input[type="text"] {
    width: 250px;
}`.

![image](https://user-images.githubusercontent.com/43155211/151665446-cf8bd709-dbc9-427d-bcbd-9d1fa569f8e1.png)

This fix essentially does the same thing as what `.workspace-leaf-content input[type="text"] {
    width: 100%;
}` did for the workspace search bar, but for the Publish search bar.

![image](https://user-images.githubusercontent.com/43155211/151665543-c15361da-e25f-4155-ad4f-b74507b5afc0.png)



