### PR TITLE
feat: outline plugin setting

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -4021,8 +4021,25 @@ body:not(.classic-inline-backlinks) :is(.writing, .longform-leaf) .embedded-back
 	background-color: transparent;
 }
 
-body:not(show-outline-buttons) .workspace-leaf-content[data-type="outline"] .nav-header {
+body:not(.show-outline-buttons) .workspace-leaf-content[data-type="outline"] .nav-header {
 	display: none;
+}
+
+body.always-show-outline-searchbar .workspace-leaf-content[data-type="outline"] .nav-header {
+	display: flex;
+	flex-direction: row-reverse;
+	justify-content: space-between;
+}
+
+/* hide search button */
+body.always-show-outline-searchbar .workspace-leaf-content[data-type="outline"] .nav-buttons-container > :first-child {
+	display: none;
+}
+
+body.always-show-outline-searchbar .workspace-leaf-content[data-type="outline"] .search-input-container {
+	display: block !important;
+	flex-grow: 1;
+	margin: 4px 0;
 }
 
 /* ───────────────────────────────────────────────── */
@@ -6261,11 +6278,19 @@ settings:
     description: By default, the sidebar for outgoing links and backlinks are reduced to linked mentions only. Enable this setting to restore their original display.
     type: class-toggle
     default: false
-  - id: show-outline-buttons
-    title: Show Outline Buttons
-    description: By default, the outline plugin buttons for collapsing, expanding, and searching headings is hidden. Enable this setting to show them again.
-    type: class-toggle
-    default: false
+  - id: outline-controls
+    title: Outline Controls
+    description: By default, the outline plugin buttons for collapsing, expanding, and searching headings are hidden.
+    type: class-select
+    allowEmpty: false
+    default: none
+    options:
+      - label: Hidden
+        value: none
+      - label: Show Buttons
+        value: show-outline-buttons
+      - label: Show Searchbar and Collapse Button
+        value: always-show-outline-searchbar
   - id: classic-inline-backlinks
     title: Use Normal Inline Backlinks
     description: By default, the inline-backlinks are displayed in a more minimalistic manner. Enable this setting to restore original display of backlinks. This also affects the Influx Plugin.


### PR DESCRIPTION
This PR changes configuration for Outline plugin, adds a new option to always show searchbar in a compact manner and fixes current show-outline-buttons setting.

![image](https://github.com/chrisgrieser/shimmering-focus/assets/36513243/d1a6f178-3b8e-45f0-91f9-e79dddfc8836)
Hidden (default)
![image](https://github.com/chrisgrieser/shimmering-focus/assets/36513243/9b7f43b2-7fc4-4b2f-ac40-a8a04cc79d3c)
Show Buttons
![image](https://github.com/chrisgrieser/shimmering-focus/assets/36513243/58d4f803-e1bf-4656-8709-04521b6f3af2)
Show Searchbar and Collapse Button
![image](https://github.com/chrisgrieser/shimmering-focus/assets/36513243/b81f31ac-c80a-4290-b251-8a8d27d416a6)


