### PR TITLE
Revert "fix: remove ribbon settings"

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -2421,6 +2421,41 @@ input[type="checkbox"].metadata-input-checkbox {
 }
 
 /* ───────────────────────────────────────────────── */
+/* << Settings Button & Ribbon
+──────────────────────────────────────────────────── */
+body:not(.show-ribbon) .workspace-ribbon.mod-left {
+	visibility: hidden;
+}
+
+body:not(.show-ribbon) .mod-left-split.is-sidedock-collapsed+.mod-root,
+body:not(.show-ribbon) .mod-left-split {
+	margin-left: calc(-1 * var(--ribbon-width));
+}
+
+body:not(.show-ribbon) .side-dock-settings .side-dock-ribbon-action:last-child:hover {
+	background-color: var(--bg3);
+}
+
+body:not(.show-ribbon, .is-mobile) .side-dock-settings .side-dock-ribbon-action:last-child {
+	position: absolute;
+	bottom: 0.5em;
+	left: 0.5em;
+	visibility: visible;
+	background-color: var(--bg4);
+	border: var(--thin-muted-border);
+	opacity: 1;
+}
+
+.hide-settings-button:not(.show-ribbon) .side-dock-settings .side-dock-ribbon-action:last-child {
+	display: none;
+}
+
+/* adjust left sidebar tab headers for hidden ribbon */
+.mod-macos.is-hidden-frameless:not(.is-fullscreen, .show-ribbon) {
+	--frame-left-space: calc(var(--ribbon-width) + 1.5vw);
+}
+
+/* ───────────────────────────────────────────────── */
 /* << Status Bar
 ──────────────────────────────────────────────────── */
 .hide-pandoc-reference-list-status-bar .status-bar-item.plugin-obsidian-pandoc-reference-list,
@@ -5104,14 +5139,21 @@ settings:
     type: heading
     level: 1
     collapsed: true
-  - id: ribbon-info
-    description: "The setting to remove the ribbon (the thin sidebar to the very left) has been removed, since you can now do so via the Obsidian settings: `Appearance → Interface → Show ribbon menu`"
-    type: info-text
+  - id: hide-settings-button
+    title: Hide Settings Button
+    type: class-toggle
+    description: Hide the floating Settings button in the bottom left. You can still access the settings by using the hotkey `⌘+,` or `ctrl+,`.
     markdown: true
+    default: false
   - id: show-sidebar-header-buttons
     title: Permanently show the Sidebar Header Buttons
     description: By default, the buttons at the top of the sidebar panels are only visible when hovering.
     type: class-toggle
+    default: false
+  - id: show-ribbon
+    title: Re-enable the Ribbon
+    type: class-toggle
+    description: The ribbon is the thin vertical bar to the very left. Without the ribbon, you can still trigger any action via the Command Palette.
     default: false
   - id: show-urls
     title: Show URLs of Markdown Links


### PR DESCRIPTION
This reverts commit 417af43a6f9520d7d29870d5d8fa3fa55c95927f.


Obsidian (v1.5.12) has no `Show ribbon menu` setting, but `Ribbon menu` instead. 

<img width="814" alt="Screenshot 2024-04-30 at 11 44 21" src="https://github.com/chrisgrieser/shimmering-focus/assets/11472839/80e91a19-c162-4e1c-a394-37f73fbc9f39">

And you can't just hide the whole ribbon:
<img width="555" alt="Screenshot 2024-04-30 at 11 53 58" src="https://github.com/chrisgrieser/shimmering-focus/assets/11472839/98a54bac-2e29-4a42-9030-c29d34c28049">

<img width="1072" alt="Screenshot 2024-04-30 at 11 54 25" src="https://github.com/chrisgrieser/shimmering-focus/assets/11472839/910b2071-e4f9-4be2-8746-65e6ddd09933">
