### PR TITLE
fix: make link to relevant section of readme go to the correct place

### DIFF
--- a/source/style-settings.yaml
+++ b/source/style-settings.yaml
@@ -258,7 +258,7 @@ settings:
     title: Use your own color scheme
     description: |
       You can create your own color scheme without any CSS knowledge by using a CSS snippet. 
-      [See the theme docs for further information](https://github.com/chrisgrieser/shimmering-focus#create-and-share-your-own-color-scheme).
+      [See the theme docs for further information](https://github.com/chrisgrieser/shimmering-focus#create-your-own-color-scheme).
 
       You can [suggest your color
       scheme for inclusion in Shimmering Focus](https://github.com/chrisgrieser/shimmering-focus/discussions/categories/suggest-your-color-scheme-for-inclusion-in-shimmering-focus).


### PR DESCRIPTION
I clicked the link to see the theme docs, but was only brought to the top of the README.
![image](https://github.com/user-attachments/assets/19048385-2057-4765-a00f-7b9ae32c3667)
As I expected, it was just a small error in the link to the specific header. Should work now.

## Checklist
- [ ] Added before/after screenshots (if applicable).
- [x] Briefly described the change.
