### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/source/3-markup/callouts.css
+++ b/source/3-markup/callouts.css
@@ -15,9 +15,9 @@
 
 .callout-title {
 	padding: 3px 6px;
-	background-color: rgb(var(--callout-color), 15%);
+	background-color: color-mix(in srgb, var(--callout-color) 15%, transparent);
 	border-bottom: var(--callout-border-width) solid
-		rgb(var(--callout-color), var(--callout-border-opacity));
+		color-mix(in srgb, var(--callout-color) calc(var(--callout-border-opacity) * 100%), transparent);
 }
 
 .HyperMD-callout,


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
